### PR TITLE
fix #3

### DIFF
--- a/src/components/VueFsRouter.vue
+++ b/src/components/VueFsRouter.vue
@@ -4,18 +4,21 @@
 
 <script setup>
 import {
-  onMounted,
+  computed,
   defineAsyncComponent,
   defineComponent,
-  computed,
   getCurrentInstance,
+  onMounted,
   provide,
   reactive,
   shallowRef,
   h,
 } from "vue";
 
+if (!location.hash) location.hash = "/";
+
 const instance = getCurrentInstance();
+
 const PageNotFound = defineComponent({
   render() {
     return h("h1", {}, "404 - Page not found");


### PR DESCRIPTION
When the router component is created check if location.hash is null and set's it to /, so the index page is initially loaded.